### PR TITLE
Simplify Counter implementation

### DIFF
--- a/values.go
+++ b/values.go
@@ -107,7 +107,7 @@ func (v *Counter) Set(s string) error {
 		*v++
 		return nil
 	}
-	parsed, err := strconv.ParseInt(s, 0, 64)
+	parsed, err := strconv.ParseInt(s, 0, 0)
 	if err != nil {
 		return err
 	}
@@ -121,19 +121,19 @@ func (v *Counter) Set(s string) error {
 }
 
 // Get method returns inner value for Counter.
-func (v *Counter) Get() interface{} { return (int)(*v) }
+func (v Counter) Get() interface{} { return int(v) }
 
 // IsBoolFlag returns true, because Counter might be used without value.
-func (v *Counter) IsBoolFlag() bool { return true }
+func (v Counter) IsBoolFlag() bool { return true }
 
 // String returns string representation of Counter
-func (v *Counter) String() string { return fmt.Sprintf("%d", *v) }
+func (v Counter) String() string { return strconv.Itoa(int(v)) }
 
 // IsCumulative returns true, because Counter might be used multiple times.
-func (v *Counter) IsCumulative() bool { return true }
+func (v Counter) IsCumulative() bool { return true }
 
 // Type returns `count` for Counter, it's mostly for pflag compatibility.
-func (v *Counter) Type() string { return "count" }
+func (v Counter) Type() string { return "count" }
 
 // === Some patches for generated flags
 


### PR DESCRIPTION
- use a pointer receiver only where necessary
- use `strconv.Itoa` instead of `fmt.Sprintf`
- fix call to `strconv.ParseInt`: the last argument must be 0 for int instead of 64 (for proper compatibility with 32 bits platform)