### PR TITLE
Fix go module package name and Makefile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,5 +57,5 @@ tools:
 	go get -u github.com/warmans/golocc
 	go get -u github.com/divan/depscheck
 	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-	cd ${GOPATH}/src/github.com/golangci/golangci-lint/cmd/golangci-lint
-    go install -ldflags "-X 'main.version=$(git describe --tags)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
+	cd ${GOPATH}/src/github.com/golangci/golangci-lint/cmd/golangci-lint \
+   && go install -ldflags "-X 'main.version=$(git describe --tags)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sflags
+module github.com/octago/sflags
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible


### PR DESCRIPTION
Fix module name in `go.mod`.  Without this change it is impossible to use this library in a project with `GO111MODULE=on`

Also fix error in `Makefile`.  `make` does not track working directory between commands.