### PR TITLE
Feature: Hide nested flags if hidden tag applied to parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,18 @@ If you specify description in description tag (`desc` by default) it will be use
 
 ```golang
 Addr string `desc:"HTTP host"`
+````
+This description produces something like:
 ```sh
-this description produces something like:
-```
   -addr value
     	HTTP host (default 127.0.0.1)
 ```
 
 ## Options for env tag
-
+If you specify environment variable name in `env` tag, it will be used to set the value of the field.
+```golang
+SSL     bool          `env:"HTTP_SSL_VALUE"`
+```
 
 ## Options for Parse function:
 
@@ -212,8 +215,14 @@ func EnvDivider(val string)
 // Check existed validators in sflags/validator package.
 func Validator(val ValidateFunc)
 
-// Set to false if you don't want anonymous structure fields to be flatten.
+// Set to false if you don't want anonymous structure fields to be flattened.
 func Flatten(val bool)
+
+// InheritHidden sets if fields should inherit the value of the hidden tag from parent structs.
+func InheritHidden()
+
+// InheritDeprecated sets if fields should inherit the value of the deprecated tag from parent structs.
+func InheritDeprecated()
 ```
 
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -125,15 +125,26 @@ func TestParseStruct(t *testing.T) {
 	deprecatedNestedCfg := &struct {
 		Sub struct {
 			Name string
+			Sub2 struct {
+				Name string
+			}
 		} `flag:",deprecated"`
-		Sub2 struct {
+		Sub3 struct {
 			Name string
 		}
 	}{
-		Sub: struct{ Name string }{
+		Sub: struct {
+			Name string
+			Sub2 struct {
+				Name string
+			}
+		}{
 			Name: "name_value",
+			Sub2: struct{ Name string }{
+				Name: "other_value",
+			},
 		},
-		Sub2: struct{ Name string }{
+		Sub3: struct{ Name string }{
 			Name: "name_value",
 		},
 	}
@@ -428,10 +439,17 @@ func TestParseStruct(t *testing.T) {
 					Deprecated: true,
 				},
 				{
-					Name:     "sub2-name",
-					EnvNames: []string{"SUB2_NAME"},
+					Name:       "sub-sub2-name",
+					EnvNames:   []string{"SUB_SUB2_NAME"},
+					DefValue:   "other_value",
+					Value:      newStringValue(&deprecatedNestedCfg.Sub.Sub2.Name),
+					Deprecated: true,
+				},
+				{
+					Name:     "sub3-name",
+					EnvNames: []string{"SUB3_NAME"},
 					DefValue: "name_value",
-					Value:    newStringValue(&deprecatedNestedCfg.Sub2.Name),
+					Value:    newStringValue(&deprecatedNestedCfg.Sub3.Name),
 				},
 			},
 		},

--- a/parser_test.go
+++ b/parser_test.go
@@ -96,6 +96,47 @@ func TestParseStruct(t *testing.T) {
 			},
 		},
 	}
+	hiddenNestedCfg := &struct {
+		Sub struct {
+			Name string
+			Sub2 struct {
+				Name string
+			}
+		} `flag:",hidden"`
+		Sub3 struct {
+			Name string
+		}
+	}{
+		Sub: struct {
+			Name string
+			Sub2 struct {
+				Name string
+			}
+		}{
+			Name: "name_value",
+			Sub2: struct{ Name string }{
+				Name: "other_value",
+			},
+		},
+		Sub3: struct{ Name string }{
+			Name: "name_value",
+		},
+	}
+	deprecatedNestedCfg := &struct {
+		Sub struct {
+			Name string
+		} `flag:",deprecated"`
+		Sub2 struct {
+			Name string
+		}
+	}{
+		Sub: struct{ Name string }{
+			Name: "name_value",
+		},
+		Sub2: struct{ Name string }{
+			Name: "name_value",
+		},
+	}
 	descCfg := &struct {
 		Name  string `desc:"name description"`
 		Name2 string `description:"name2 description"`
@@ -346,6 +387,53 @@ func TestParseStruct(t *testing.T) {
 				},
 			},
 			expErr: nil,
+		},
+		{
+			name:     "Inherit hidden parent flag",
+			cfg:      hiddenNestedCfg,
+			optFuncs: []OptFunc{InheritHidden()},
+			expFlagSet: []*Flag{
+				{
+					Name:     "sub-name",
+					EnvNames: []string{"SUB_NAME"},
+					DefValue: "name_value",
+					Value:    newStringValue(&hiddenNestedCfg.Sub.Name),
+					Hidden:   true,
+				},
+				{
+					Name:     "sub-sub2-name",
+					EnvNames: []string{"SUB_SUB2_NAME"},
+					DefValue: "other_value",
+					Value:    newStringValue(&hiddenNestedCfg.Sub.Sub2.Name),
+					Hidden:   true,
+				},
+				{
+					Name:     "sub3-name",
+					EnvNames: []string{"SUB3_NAME"},
+					DefValue: "name_value",
+					Value:    newStringValue(&hiddenNestedCfg.Sub3.Name),
+				},
+			},
+		},
+		{
+			name:     "Inherit deprecated parent flag",
+			cfg:      deprecatedNestedCfg,
+			optFuncs: []OptFunc{InheritDeprecated()},
+			expFlagSet: []*Flag{
+				{
+					Name:       "sub-name",
+					EnvNames:   []string{"SUB_NAME"},
+					DefValue:   "name_value",
+					Value:      newStringValue(&deprecatedNestedCfg.Sub.Name),
+					Deprecated: true,
+				},
+				{
+					Name:     "sub2-name",
+					EnvNames: []string{"SUB2_NAME"},
+					DefValue: "name_value",
+					Value:    newStringValue(&deprecatedNestedCfg.Sub2.Name),
+				},
+			},
 		},
 		{
 			name:     "DescCfg with custom desc tag",


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

This change introduces two new options `InheritHidden` and `InheritDeprecated` which can be used with the `Parse*` functions to mark all nested flags as either `hidden` or `deprecated` if a parent `struct` has been tagged as either `hidden` or `deprecated`.

For example given the following `struct` definition
```golang
type Details struct {
    Name string
    Age.  int
}

type Config struct {
    Details Details `flag:",hidden"`
    Verbose bool
}
```

and a parser that looks like 
```golang
var c Config
flags.ParseStruct(&c, flags.InheritHidden())
```

you would end up with something like
```
Flags:
      --verbose
```
instead of
```golang
Flags:
      --details-name
      --details-age
      --verbose
```

I had initially made this behaviour default behaviour, but refactored to options in order to not break backwards compatibility.
<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

n/a

## Special notes for your reviewer:
I don't really like having both `inheritHidden` and `hidden` options, but I haven't been able to figure out how to combine them. If you have any suggestions please let me know.


<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

New test cases have been added to `parser_test.go` to test the behaviour

## Release Notes

```release-note
* Add `InheritHidden` and `InheritDeprecated` options in order for flags to inherit the `hidden` or `deprecated` tags from a parent struct when using nested structs.
```
